### PR TITLE
Fix example with correct flag for features

### DIFF
--- a/examples/fast-mrmr
+++ b/examples/fast-mrmr
@@ -3,4 +3,4 @@
 cd fast-mRMR/cpu/src
 make
 chmod +x fast-mrmr
-./fast-mrmr -f ../data.mrmr -n 50
+./fast-mrmr -f ../data.mrmr -a 50


### PR DESCRIPTION
A minor fix to add the correct flag in the example script for selecting the number of features. It was `-n`, but should be `-a`.